### PR TITLE
Replace per-frame allocation of StateSet and Viewport

### DIFF
--- a/apps/openmw/mwrender/postprocessor.cpp
+++ b/apps/openmw/mwrender/postprocessor.cpp
@@ -124,6 +124,8 @@ namespace MWRender
         , mSamples(Settings::video().mAntialiasing)
         , mPingPongCull(new PingPongCull(this))
         , mDistortionCallback(new DistortionCallback)
+        , mScaledViewportStateSet(new osg::StateSet)
+        , mScaledViewport(new osg::Viewport)
     {
         auto& shaderManager = mRendering.getResourceSystem()->getSceneManager()->getShaderManager();
 
@@ -146,6 +148,9 @@ namespace MWRender
         mHUDCamera->addChild(mCanvases[1]);
         mHUDCamera->setCullCallback(new HUDCullCallback);
         mViewer->getCamera()->addCullCallback(mPingPongCull);
+
+        // Initialize scaled viewport state set
+        mScaledViewportStateSet->setAttribute(mScaledViewport);
 
         // resolves the multisampled depth buffer and optionally draws an additional depth postpass
         mTransparentDepthPostPass
@@ -277,17 +282,17 @@ namespace MWRender
     void PostProcessor::traverse(osg::NodeVisitor& nv)
     {
         size_t frameId = nv.getTraversalNumber() % 2;
-        osg::StateSet* pushedStateSet = nullptr;
+        bool pushedStateSet = false;
 
         if (nv.getVisitorType() == osg::NodeVisitor::CULL_VISITOR)
         {
             // Push a small, scaled viewport for all children. This will be overridden by the HUD camera's callback.
             osgUtil::CullVisitor* cv = static_cast<osgUtil::CullVisitor*>(&nv);
-            pushedStateSet = new osg::StateSet;
-            pushedStateSet->setAttribute(new osg::Viewport(0, 0, renderWidth(), renderHeight()));
-            cv->pushStateSet(pushedStateSet);
+            mScaledViewport->setViewport(0, 0, renderWidth(), renderHeight());
+            cv->pushStateSet(mScaledViewportStateSet.get());
+            pushedStateSet = true;
 
-            cull(frameId, static_cast<osgUtil::CullVisitor*>(&nv));
+            cull(frameId, cv);
         }
         else if (nv.getVisitorType() == osg::NodeVisitor::UPDATE_VISITOR)
             update(frameId);

--- a/apps/openmw/mwrender/postprocessor.hpp
+++ b/apps/openmw/mwrender/postprocessor.hpp
@@ -266,6 +266,8 @@ namespace MWRender
         std::array<osg::ref_ptr<PingPongCanvas>, 2> mCanvases;
         osg::ref_ptr<TransparentDepthBinCallback> mTransparentDepthPostPass;
         osg::ref_ptr<DistortionCallback> mDistortionCallback;
+        osg::ref_ptr<osg::StateSet> mScaledViewportStateSet;
+        osg::ref_ptr<osg::Viewport> mScaledViewport;
 
         fx::DispatchArray mTemplateData;
     };


### PR DESCRIPTION
My read of the previous code has this line:

```
pushedStateSet = new osg::StateSet;
pushedStateSet->setAttribute(new osg::Viewport(0, 0, renderWidth(), renderHeight()));
```
Leaking the two objects because I can't see how they were ever free'd.  This seems like a memory leak to me, but at best it's doing a lot of allocations that could just be done once at construction time.  This PR fixes that.