### PR TITLE
Texture memory fixes

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -737,7 +737,7 @@ void OMW::Engine::prepareEngine()
         mVFS.get(), Settings::cells().mCacheExpiryDelay, &mEncoder.get()->getStatelessEncoder());
     mResourceSystem->getSceneManager()->getShaderManager().setMaxTextureUnits(mGlMaxTextureImageUnits);
     mResourceSystem->getSceneManager()->setUnRefImageDataAfterApply(
-        false); // keep to Off for now to allow better state sharing
+        true); // Enable to reduce memory usage by freeing texture data after GPU upload
     mResourceSystem->getSceneManager()->setFilterSettings(Settings::general().mTextureMagFilter,
         Settings::general().mTextureMinFilter, Settings::general().mTextureMipmap, Settings::general().mAnisotropy);
     mEnvironment.setResourceSystem(*mResourceSystem);

--- a/components/resource/imagemanager.cpp
+++ b/components/resource/imagemanager.cpp
@@ -87,10 +87,15 @@ namespace Resource
 
     osg::ref_ptr<osg::Image> ImageManager::getImage(VFS::Path::NormalizedView path, bool disableFlip)
     {
-        osg::ref_ptr<osg::Object> obj = mCache->getRefFromObjectCache(path);
-        if (obj)
-            return osg::ref_ptr<osg::Image>(static_cast<osg::Image*>(obj.get()));
-        else
+        // Check cache first if caching is enabled
+        if (mCacheEnabled)
+        {
+            osg::ref_ptr<osg::Object> obj = mCache->getRefFromObjectCache(path);
+            if (obj)
+                return osg::ref_ptr<osg::Image>(static_cast<osg::Image*>(obj.get()));
+        }
+
+        // Load image from disk
         {
             Files::IStreamPtr stream;
             try
@@ -100,7 +105,8 @@ namespace Resource
             catch (std::exception& e)
             {
                 Log(Debug::Error) << "Failed to open image: " << e.what();
-                mCache->addEntryToObjectCache(path.value(), mWarningImage);
+                if (mCacheEnabled)
+                    mCache->addEntryToObjectCache(path.value(), mWarningImage);
                 return mWarningImage;
             }
 
@@ -109,7 +115,8 @@ namespace Resource
             if (!reader)
             {
                 Log(Debug::Error) << "Error loading " << path << ": no readerwriter for '" << ext << "' found";
-                mCache->addEntryToObjectCache(path.value(), mWarningImage);
+                if (mCacheEnabled)
+                    mCache->addEntryToObjectCache(path.value(), mWarningImage);
                 return mWarningImage;
             }
 
@@ -122,7 +129,8 @@ namespace Resource
                 if (stream->gcount() != 18)
                 {
                     Log(Debug::Error) << "Error loading " << path << ": couldn't read TGA header";
-                    mCache->addEntryToObjectCache(path.value(), mWarningImage);
+                    if (mCacheEnabled)
+                        mCache->addEntryToObjectCache(path.value(), mWarningImage);
                     return mWarningImage;
                 }
                 int type = header[2];
@@ -142,7 +150,8 @@ namespace Resource
             {
                 Log(Debug::Error) << "Error loading " << path << ": " << result.message() << " code "
                                   << result.status();
-                mCache->addEntryToObjectCache(path.value(), mWarningImage);
+                if (mCacheEnabled)
+                    mCache->addEntryToObjectCache(path.value(), mWarningImage);
                 return mWarningImage;
             }
 
@@ -155,7 +164,8 @@ namespace Resource
                 if (!uncompress)
                 {
                     Log(Debug::Error) << "Error loading " << path << ": no S3TC texture compression support installed";
-                    mCache->addEntryToObjectCache(path.value(), mWarningImage);
+                    if (mCacheEnabled)
+                        mCache->addEntryToObjectCache(path.value(), mWarningImage);
                     return mWarningImage;
                 }
                 else
@@ -186,7 +196,9 @@ namespace Resource
                 image = newImage;
             }
 
-            mCache->addEntryToObjectCache(path.value(), image);
+            // Only cache if caching is enabled
+            if (mCacheEnabled)
+                mCache->addEntryToObjectCache(path.value(), image);
             return image;
         }
     }

--- a/components/resource/imagemanager.hpp
+++ b/components/resource/imagemanager.hpp
@@ -33,7 +33,12 @@ namespace Resource
 
         void reportStats(unsigned int frameNumber, osg::Stats* stats) const override;
 
+        /// Enable or disable caching of loaded images
+        void setCacheEnabled(bool enabled) { mCacheEnabled = enabled; }
+        bool isCacheEnabled() const { return mCacheEnabled; }
+
     private:
+        bool mCacheEnabled = true;
         osg::ref_ptr<osg::Image> mWarningImage;
         osg::ref_ptr<osgDB::Options> mOptions;
         osg::ref_ptr<osgDB::Options> mOptionsNoFlip;

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -846,7 +846,17 @@ namespace Resource
     {
         const std::string_view ext = Misc::getFileExtension(normalizedFilename.value());
         if (ext == "nif")
-            return NifOsg::Loader::load(*nifFileManager->get(normalizedFilename), imageManager, materialMgr);
+        {
+            // Temporarily disable image caching during NIF loading to reduce memory spikes
+            bool oldCacheState = imageManager->isCacheEnabled();
+            imageManager->setCacheEnabled(false);
+
+            osg::ref_ptr<osg::Node> result = NifOsg::Loader::load(*nifFileManager->get(normalizedFilename), imageManager, materialMgr);
+
+            // Restore original cache state
+            imageManager->setCacheEnabled(oldCacheState);
+            return result;
+        }
         else if (ext == "spt")
         {
             Log(Debug::Warning) << "Ignoring SpeedTree data file " << normalizedFilename;

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -159,10 +159,11 @@ namespace Resource
     {
     public:
         SetFilterSettingsControllerVisitor(
-            osg::Texture::FilterMode minFilter, osg::Texture::FilterMode magFilter, int maxAnisotropy)
+            osg::Texture::FilterMode minFilter, osg::Texture::FilterMode magFilter, int maxAnisotropy, bool unRefImageDataAfterApply)
             : mMinFilter(minFilter)
             , mMagFilter(magFilter)
             , mMaxAnisotropy(maxAnisotropy)
+            , mUnRefImageDataAfterApply(unRefImageDataAfterApply)
         {
         }
 
@@ -177,6 +178,7 @@ namespace Resource
                     tex->setFilter(osg::Texture::MIN_FILTER, mMinFilter);
                     tex->setFilter(osg::Texture::MAG_FILTER, mMagFilter);
                     tex->setMaxAnisotropy(mMaxAnisotropy);
+                    tex->setUnRefImageDataAfterApply(mUnRefImageDataAfterApply);
                 }
             }
         }
@@ -185,6 +187,7 @@ namespace Resource
         osg::Texture::FilterMode mMinFilter;
         osg::Texture::FilterMode mMagFilter;
         int mMaxAnisotropy;
+        bool mUnRefImageDataAfterApply;
     };
 
     /// Set texture filtering settings on textures contained in StateSets.
@@ -192,11 +195,12 @@ namespace Resource
     {
     public:
         SetFilterSettingsVisitor(
-            osg::Texture::FilterMode minFilter, osg::Texture::FilterMode magFilter, int maxAnisotropy)
+            osg::Texture::FilterMode minFilter, osg::Texture::FilterMode magFilter, int maxAnisotropy, bool unRefImageDataAfterApply)
             : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
             , mMinFilter(minFilter)
             , mMagFilter(magFilter)
             , mMaxAnisotropy(maxAnisotropy)
+            , mUnRefImageDataAfterApply(unRefImageDataAfterApply)
         {
         }
 
@@ -228,6 +232,7 @@ namespace Resource
                 tex->setFilter(osg::Texture::MIN_FILTER, mMinFilter);
                 tex->setFilter(osg::Texture::MAG_FILTER, mMagFilter);
                 tex->setMaxAnisotropy(mMaxAnisotropy);
+                tex->setUnRefImageDataAfterApply(mUnRefImageDataAfterApply);
             }
         }
 
@@ -235,6 +240,7 @@ namespace Resource
         osg::Texture::FilterMode mMinFilter;
         osg::Texture::FilterMode mMagFilter;
         int mMaxAnisotropy;
+        bool mUnRefImageDataAfterApply;
     };
 
     // Check Collada extra descriptions
@@ -463,7 +469,7 @@ namespace Resource
         , mMinFilter(osg::Texture::LINEAR_MIPMAP_LINEAR)
         , mMagFilter(osg::Texture::LINEAR)
         , mMaxAnisotropy(1)
-        , mUnRefImageDataAfterApply(false)
+        , mUnRefImageDataAfterApply(true)
         , mParticleSystemMask(~0u)
     {
     }
@@ -1013,10 +1019,10 @@ namespace Resource
             }
 
             // set filtering settings
-            SetFilterSettingsVisitor setFilterSettingsVisitor(mMinFilter, mMagFilter, mMaxAnisotropy);
+            SetFilterSettingsVisitor setFilterSettingsVisitor(mMinFilter, mMagFilter, mMaxAnisotropy, mUnRefImageDataAfterApply);
             loaded->accept(setFilterSettingsVisitor);
             SetFilterSettingsControllerVisitor setFilterSettingsControllerVisitor(
-                mMinFilter, mMagFilter, mMaxAnisotropy);
+                mMinFilter, mMagFilter, mMaxAnisotropy, mUnRefImageDataAfterApply);
             loaded->accept(setFilterSettingsControllerVisitor);
 
             SceneUtil::ReplaceDepthVisitor replaceDepthVisitor;
@@ -1168,8 +1174,8 @@ namespace Resource
         mMagFilter = mag;
         mMaxAnisotropy = std::max(1, maxAnisotropy);
 
-        SetFilterSettingsControllerVisitor setFilterSettingsControllerVisitor(mMinFilter, mMagFilter, mMaxAnisotropy);
-        SetFilterSettingsVisitor setFilterSettingsVisitor(mMinFilter, mMagFilter, mMaxAnisotropy);
+        SetFilterSettingsControllerVisitor setFilterSettingsControllerVisitor(mMinFilter, mMagFilter, mMaxAnisotropy, mUnRefImageDataAfterApply);
+        SetFilterSettingsVisitor setFilterSettingsVisitor(mMinFilter, mMagFilter, mMaxAnisotropy, mUnRefImageDataAfterApply);
 
         mCache->accept(setFilterSettingsVisitor);
         mCache->accept(setFilterSettingsControllerVisitor);
@@ -1180,6 +1186,7 @@ namespace Resource
         tex->setFilter(osg::Texture::MIN_FILTER, mMinFilter);
         tex->setFilter(osg::Texture::MAG_FILTER, mMagFilter);
         tex->setMaxAnisotropy(mMaxAnisotropy);
+        tex->setUnRefImageDataAfterApply(mUnRefImageDataAfterApply);
     }
 
     void SceneManager::setUnRefImageDataAfterApply(bool unref)


### PR DESCRIPTION
This contains two fixes:

1. free up textures that have been sent to the GPU
2. refrain from caching image assets during Cell/Nif loading, which makes them load lazily instead