### PR TITLE
ktx support

### DIFF
--- a/components/misc/resourcehelpers.cpp
+++ b/components/misc/resourcehelpers.cpp
@@ -109,20 +109,39 @@ std::string Misc::ResourceHelpers::correctResourcePath(std::span<const std::stri
 // Note: Bethesda at some point converted all their BSA textures from tga to dds for increased load speed,
 // but all texture file name references were kept as .tga. So we pass ext=".dds" to all helpers
 // looking for textures.
+// We now prioritize KTX files first (for ASTC and other modern formats), then fall back to DDS, then original extension.
 
 std::string Misc::ResourceHelpers::correctTexturePath(std::string_view resPath, const VFS::Manager* vfs)
 {
-    return correctResourcePath({ { "textures", "bookart" } }, resPath, vfs, ".dds");
+    // Try KTX first, then DDS, then original extension
+    std::string correctedPath = correctResourcePath({ { "textures", "bookart" } }, resPath, vfs, ".ktx");
+    if (!vfs->exists(correctedPath))
+    {
+        correctedPath = correctResourcePath({ { "textures", "bookart" } }, resPath, vfs, ".dds");
+    }
+    return correctedPath;
 }
 
 std::string Misc::ResourceHelpers::correctIconPath(std::string_view resPath, const VFS::Manager* vfs)
 {
-    return correctResourcePath({ { "icons" } }, resPath, vfs, ".dds");
+    // Try KTX first, then DDS, then original extension
+    std::string correctedPath = correctResourcePath({ { "icons" } }, resPath, vfs, ".ktx");
+    if (!vfs->exists(correctedPath))
+    {
+        correctedPath = correctResourcePath({ { "icons" } }, resPath, vfs, ".dds");
+    }
+    return correctedPath;
 }
 
 std::string Misc::ResourceHelpers::correctBookartPath(std::string_view resPath, const VFS::Manager* vfs)
 {
-    return correctResourcePath({ { "bookart", "textures" } }, resPath, vfs, ".dds");
+    // Try KTX first, then DDS, then original extension
+    std::string correctedPath = correctResourcePath({ { "bookart", "textures" } }, resPath, vfs, ".ktx");
+    if (!vfs->exists(correctedPath))
+    {
+        correctedPath = correctResourcePath({ { "bookart", "textures" } }, resPath, vfs, ".dds");
+    }
+    return correctedPath;
 }
 
 std::string Misc::ResourceHelpers::correctBookartPath(

--- a/components/resource/imagemanager.cpp
+++ b/components/resource/imagemanager.cpp
@@ -5,6 +5,7 @@
 
 #include <components/debug/debuglog.hpp>
 #include <components/misc/pathhelpers.hpp>
+#include <components/misc/resourcehelpers.hpp>
 #include <components/sceneutil/glextensions.hpp>
 #include <components/vfs/manager.hpp>
 #include <components/vfs/pathutil.hpp>
@@ -87,7 +88,33 @@ namespace Resource
 
     osg::ref_ptr<osg::Image> ImageManager::getImage(VFS::Path::NormalizedView path, bool disableFlip)
     {
-        osg::ref_ptr<osg::Object> obj = mCache->getRefFromObjectCache(path);
+        // Always prioritize KTX over DDS over original format
+        std::string resolvedPath(path.value());
+
+        // Try KTX first (highest priority)
+        VFS::Path::Normalized ktxPath(path);
+        ktxPath.changeExtension("ktx");
+        if (mVFS->exists(ktxPath))
+        {
+            resolvedPath = ktxPath.value();
+            Log(Debug::Info) << "ImageManager: Using KTX format " << path << " -> " << resolvedPath;
+        }
+        // Then try DDS (second priority)
+        else
+        {
+            VFS::Path::Normalized ddsPath(path);
+            ddsPath.changeExtension("dds");
+            if (mVFS->exists(ddsPath))
+            {
+                resolvedPath = ddsPath.value();
+                Log(Debug::Info) << "ImageManager: Using DDS format " << path << " -> " << resolvedPath;
+            }
+            // Otherwise use original path (lowest priority)
+        }
+
+        // Use the resolved path for caching
+        VFS::Path::Normalized finalPath(resolvedPath);
+        osg::ref_ptr<osg::Object> obj = mCache->getRefFromObjectCache(finalPath);
         if (obj)
             return osg::ref_ptr<osg::Image>(static_cast<osg::Image*>(obj.get()));
         else
@@ -95,21 +122,21 @@ namespace Resource
             Files::IStreamPtr stream;
             try
             {
-                stream = mVFS->get(path);
+                stream = mVFS->get(finalPath);
             }
             catch (std::exception& e)
             {
                 Log(Debug::Error) << "Failed to open image: " << e.what();
-                mCache->addEntryToObjectCache(path.value(), mWarningImage);
+                mCache->addEntryToObjectCache(finalPath.value(), mWarningImage);
                 return mWarningImage;
             }
 
-            const std::string ext(Misc::getFileExtension(path.value()));
+            const std::string ext(Misc::getFileExtension(finalPath.value()));
             osgDB::ReaderWriter* reader = osgDB::Registry::instance()->getReaderWriterForExtension(ext);
             if (!reader)
             {
-                Log(Debug::Error) << "Error loading " << path << ": no readerwriter for '" << ext << "' found";
-                mCache->addEntryToObjectCache(path.value(), mWarningImage);
+                Log(Debug::Error) << "Error loading " << finalPath << ": no readerwriter for '" << ext << "' found";
+                mCache->addEntryToObjectCache(finalPath.value(), mWarningImage);
                 return mWarningImage;
             }
 
@@ -121,8 +148,8 @@ namespace Resource
                 stream->read((char*)header, 18);
                 if (stream->gcount() != 18)
                 {
-                    Log(Debug::Error) << "Error loading " << path << ": couldn't read TGA header";
-                    mCache->addEntryToObjectCache(path.value(), mWarningImage);
+                    Log(Debug::Error) << "Error loading " << finalPath << ": couldn't read TGA header";
+                    mCache->addEntryToObjectCache(finalPath.value(), mWarningImage);
                     return mWarningImage;
                 }
                 int type = header[2];
@@ -140,22 +167,22 @@ namespace Resource
                 = reader->readImage(*stream, disableFlip ? mOptionsNoFlip : mOptions);
             if (!result.success())
             {
-                Log(Debug::Error) << "Error loading " << path << ": " << result.message() << " code "
+                Log(Debug::Error) << "Error loading " << finalPath << ": " << result.message() << " code "
                                   << result.status();
-                mCache->addEntryToObjectCache(path.value(), mWarningImage);
+                mCache->addEntryToObjectCache(finalPath.value(), mWarningImage);
                 return mWarningImage;
             }
 
             osg::ref_ptr<osg::Image> image = result.getImage();
 
-            image->setFileName(std::string(path.value()));
+            image->setFileName(std::string(finalPath.value()));
             if (!checkSupported(image))
             {
                 static bool uncompress = (getenv("OPENMW_DECOMPRESS_TEXTURES") != nullptr);
                 if (!uncompress)
                 {
-                    Log(Debug::Error) << "Error loading " << path << ": no S3TC texture compression support installed";
-                    mCache->addEntryToObjectCache(path.value(), mWarningImage);
+                    Log(Debug::Error) << "Error loading " << finalPath << ": no S3TC texture compression support installed";
+                    mCache->addEntryToObjectCache(finalPath.value(), mWarningImage);
                     return mWarningImage;
                 }
                 else
@@ -186,7 +213,7 @@ namespace Resource
                 image = newImage;
             }
 
-            mCache->addEntryToObjectCache(path.value(), image);
+            mCache->addEntryToObjectCache(finalPath.value(), image);
             return image;
         }
     }


### PR DESCRIPTION
We prioritize KTX textures of the same name over any other texture file. These may include ASTC and are passed wholesale through to OpenSceneGraph which can handle them.